### PR TITLE
Docker build uses local code instead of pypi package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,17 @@ RUN dnf5 install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-r
     ffmpeg && \
     dnf5 clean all -y
 
+WORKDIR /app
+COPY src/ /app/
+COPY .config/requirements.in ./
+
 RUN pip install --force-reinstall -v "Pillow==9.5.0" && \
-    pip install --root-user-action=ignore home-journal==0.0.8
+    pip install -r /app/requirements.in
 
 VOLUME [ "/mnt/site" ]
 EXPOSE 8000
 
-ENTRYPOINT ["home-journal"]
+ENTRYPOINT ["python", "-m", "home_journal"]
 CMD ["--log_file", "/mnt/site/hj.log", \
     "--log_level","debug", \
     "--site_directory", "/mnt/site", \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,5 @@ services:
     build: ./
     volumes:
       - ./site:/mnt/site
+      - ./src:/app
     ports: [ 8000:8000 ]


### PR DESCRIPTION
This PR changes the docker build process by installing the dependencies from the local requirements file and copying the source code instead of installing the package and it's dependencies from pypi.